### PR TITLE
Remove CMD from Dockerfiles

### DIFF
--- a/Dockerfile-nodepool-fedora
+++ b/Dockerfile-nodepool-fedora
@@ -19,5 +19,3 @@ RUN mkdir -p \
     /var/lib/nodepool
 
 COPY root/etc/nodepool /etc/nodepool
-
-CMD /bin/bash

--- a/Dockerfile-zuul-fedora
+++ b/Dockerfile-zuul-fedora
@@ -18,5 +18,3 @@ RUN mkdir \
 
 COPY root/etc/zuul/zuul.conf /etc/zuul/zuul.conf
 COPY root/etc/zuul/tenant.yaml /etc/zuul/tenant.yaml
-
-CMD /bin/bash


### PR DESCRIPTION
Since the command is being set in docker-compose.yml, we don't need to
set it here.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>